### PR TITLE
Implement lookAt in Matrix4

### DIFF
--- a/src/lib/matrix4.js
+++ b/src/lib/matrix4.js
@@ -193,6 +193,90 @@ class Matrix4 extends Float32Array {
   }
 
   /**
+   * Set this matrix to a view matrix matching the given eye, center, and up
+   * vectors.
+   *
+   * This implementation is compatible with GxuXformCreateLookAtSgCompat.
+   *
+   * @param {Vector3} eye Origin of the view
+   * @param {Vector3} center Target of the view
+   * @param {Vector3} up Vector pointing up
+   * @returns {Matrix4} Self
+   */
+  lookAt(eye, center, up) {
+    const ex = eye[0],    ey = eye[1],    ez = eye[2];
+    const cx = center[0], cy = center[1], cz = center[2];
+    const ux = up[0],     uy = up[1],     uz = up[2];
+
+    let m = 0.0;
+
+    // z = sub(center, eye)
+    let zx = cx - ex;
+    let zy = cy - ey;
+    let zz = cz - ez;
+
+    // Extremely close target
+    if (Math.abs(zx) < EPSILON && Math.abs(zy) < EPSILON && Math.abs(zz) < EPSILON) {
+      this.set(DEFAULT);
+      return this;
+    }
+
+    // z = normalize(z)
+    m = 1.0 / Math.sqrt(zx * zx + zy * zy + zz * zz);
+
+    zx *= m;
+    zy *= m;
+    zz *= m;
+
+    // x = cross(z, up)
+    let xx = zy * uz - zz * uy;
+    let xy = zz * ux - zx * uz;
+    let xz = zx * uy - zy * ux;
+
+    // x = normalize(x)
+    m = xx * xx + xy * xy + xz * xz;
+
+    if (m === 0.0) {
+      xx = 0.0;
+      xy = 0.0;
+      xz = 0.0;
+    } else {
+      m = 1.0 / Math.sqrt(m);
+
+      xx *= m;
+      xy *= m;
+      xz *= m;
+    }
+
+    // y = cross(x, z)
+    let yx = xy * zz - xz * zy;
+    let yy = xz * zx - xx * zz;
+    let yz = xx * zy - xy * zx;
+
+    this[0]  = xx;
+    this[1]  = yx;
+    this[2]  = zx;
+    this[3]  = 0.0;
+
+    this[4]  = xy;
+    this[5]  = yy;
+    this[6]  = zy;
+    this[7]  = 0.0;
+
+    this[8]  = xz;
+    this[9]  = yz;
+    this[10] = zz;
+    this[11] = 0.0;
+
+    this[12] = -(xx * ex + xy * ey + xz * ez);
+    this[13] = -(yx * ex + yy * ey + yz * ez);
+    this[14] = -(zx * ex + zy * ey + zz * ez);
+    this[15] = 1.0;
+
+    return this;
+  }
+
+  /**
    * Multiply this matrix by given matrix m.
    *
    * @param {Matrix4} m Matrix to multiply by

--- a/src/specs/matrix4.spec.js
+++ b/src/specs/matrix4.spec.js
@@ -149,6 +149,138 @@ describe('Matrix4', () => {
     });
   });
 
+  describe('prototype.lookAt()', () => {
+    test('creates view matrix with positive offset from eye to center, and z up vector', () => {
+      const eye = Vector3.of(1.0, 1.0, 1.0);
+      const center = Vector3.of(10.0, 10.0, 10.0);
+      const up = Vector3.of(0.0, 0.0, 1.0);
+
+      const matrix = new Matrix4().lookAt(eye, center, up);
+
+      /* eslint-disable */
+      expect(matrix.approximates(Matrix4.of(
+         0.7071068287, -0.4082481861,  0.5773502588, 0.0, // col 0
+        -0.7071067095, -0.4082484245,  0.5773502588, 0.0, // col 1
+         0.0,           0.8164966106,  0.5773502588, 0.0, // col 2
+         0.0,           0.0,          -1.732050776,  1.0  // col 3
+      ))).toBe(true);
+      /* eslint-enable */
+    });
+
+    test('creates view matrix with positive offset from eye to center, and y up vector', () => {
+      const eye = Vector3.of(1.0, 1.0, 1.0);
+      const center = Vector3.of(10.0, 10.0, 10.0);
+      const up = Vector3.of(0.0, 1.0, 0.0);
+
+      const matrix = new Matrix4().lookAt(eye, center, up);
+
+      /* eslint-disable */
+      expect(matrix.approximates(Matrix4.of(
+        -0.7071067691, -0.4082483053,  0.5773502588, 0.0, // col 0
+         0.0,           0.8164966106,  0.5773502588, 0.0, // col 1
+         0.7071067691, -0.4082483053,  0.5773502588, 0.0, // col 2
+         0.0,           0.0,          -1.732050776,  1.0  // col 3
+      ))).toBe(true);
+      /* eslint-enable */
+    });
+
+    test('creates view matrix with negative offset from eye to center, and z up vector', () => {
+      const eye = Vector3.of(1.0, 2.0, 3.0);
+      const center = Vector3.of(-21.0, -11.0, -9.0);
+      const up = Vector3.of(0.0, 0.0, 1.0);
+
+      const matrix = new Matrix4().lookAt(eye, center, up);
+
+      /* eslint-disable */
+      expect(matrix.approximates(Matrix4.of(
+        -0.5087293386, -0.3659469187, -0.7792800069, 0.0, // col 0
+         0.8609265089, -0.2162415236, -0.4604836404, 0.0, // col 1
+         0.0,           0.9051643014, -0.4250618219, 0.0, // col 2
+        -1.213124156,  -1.917062998,   2.975432873,  1.0  // col 3
+      ))).toBe(true);
+      /* eslint-enable */
+    });
+
+    test('creates view matrix from identical eye and center', () => {
+      const eye = Vector3.of(0.0, 0.0, 0.0);
+      const center = Vector3.of(0.0, 0.0, 0.0);
+      const up = Vector3.of(0.0, 0.0, 1.0);
+
+      const matrix = new Matrix4().lookAt(eye, center, up);
+
+      expect(matrix.approximates(Matrix4.of(
+        1.0, 0.0, 0.0, 0.0, // col 0
+        0.0, 1.0, 0.0, 0.0, // col 1
+        0.0, 0.0, 1.0, 0.0, // col 2
+        0.0, 0.0, 0.0, 1.0  // col 3
+      ))).toBe(true);
+    });
+
+    test('creates view matrix with zero up vector', () => {
+      const eye = Vector3.of(0.0, 0.0, 0.0);
+      const center = Vector3.of(1.0, 1.0, 1.0);
+      const up = Vector3.of(0.0, 0.0, 0.0);
+
+      const matrix = new Matrix4().lookAt(eye, center, up);
+
+      expect(matrix.approximates(Matrix4.of(
+        0.0, 0.0, 0.577350, 0.0, // col 0
+        0.0, 0.0, 0.577350, 0.0, // col 1
+        0.0, 0.0, 0.577350, 0.0, // col 2
+        0.0, 0.0, 0.0,      1.0  // col 3
+      ))).toBe(true);
+    });
+
+    test('creates view matrix from sampled data a', () => {
+      const eye = Vector3.of(0.0, 0.0, 0.0);
+      const center = Vector3.of(-18.9, 0.0, 0.0);
+      const up = Vector3.of(0.0, 0.0, 1.0);
+
+      const matrix = new Matrix4().lookAt(eye, center, up);
+
+      expect(matrix.approximates(Matrix4.of(
+        0.0, 0.0, -1.0, 0.0, // col 0
+        1.0, 0.0,  0.0, 0.0, // col 1
+        0.0, 1.0,  0.0, 0.0, // col 2
+        0.0, 0.0,  0.0, 1.0  // col 3
+      ))).toBe(true);
+    });
+
+    test('creates view matrix from sampled data b', () => {
+      const eye = Vector3.of(0.0, 0.0, 0.0);
+      const center = Vector3.of(-8.28, -0.09, 0.81);
+      const up = Vector3.of(0.0, 0.0, 1.0);
+
+      const matrix = new Matrix4().lookAt(eye, center, up);
+
+      /* eslint-disable */
+      expect(matrix.approximates(Matrix4.of(
+        -0.010868, 0.097349, -0.995190, 0.0, // col 0
+         0.999940, 0.001058, -0.010817, 0.0, // col 1
+         0.0,      0.995249,  0.097355, 0.0, // col 2
+         0.0,      0.0,       0.0,      1.0  // col 3
+      ))).toBe(true);
+      /* eslint-enable */
+    });
+
+    test('creates view matrix from sampled data c', () => {
+      const eye = Vector3.of(0.0, 0.0, 0.0);
+      const center = Vector3.of(0.8591673374, 0.320672214, -0.3987491131);
+      const up = Vector3.of(0.0, 0.0, 1.0);
+
+      const matrix = new Matrix4().lookAt(eye, center, up);
+
+      /* eslint-disable */
+      expect(matrix.approximates(Matrix4.of(
+         0.3496741652, 0.3735766112,  0.8591673374, 0.0, // col 0
+        -0.9368713498, 0.1394322663,  0.3206722140, 0.0, // col 1
+         0.0,          0.9170600771, -0.3987491130, 0.0, // col 2
+         0.0,          0.0,           0.0,          1.0  // col 3
+      ))).toBe(true);
+      /* eslint-enable */
+    });
+  });
+
   describe('prototype.multiply()', () => {
     test('multiplies this matrix by given matrix', () => {
       const matrix1 = Matrix4.of(


### PR DESCRIPTION
This implementation matches the logic used in the client function `GxuXformCreateLookAtSgCompat`. It calculates a right-handed look-at, with a few oddities around signs for the forward axis.

The three sampled data unit tests use data I've pulled from the client at runtime using a debugger. I might try add a few more sampled data tests at some point, but it's a bit tedious.

Closes #6 