### PR TITLE
Refactor perspective projection in Matrix4

### DIFF
--- a/src/lib/matrix4.js
+++ b/src/lib/matrix4.js
@@ -237,17 +237,31 @@ class Matrix4 extends Float32Array {
 
   /**
    * Set this matrix to a perspective projection matrix matching the given
-   * field of view, aspect ratio, near frustum, and far frustum.
+   * vertical field of view, aspect ratio, near frustum, and far frustum.
    *
-   * @param {Number} fov Field of view (in radians)
+   * The resulting projection matrix is left-handed and has a depth range
+   * from -1-to-1.
+   *
+   * This implementation is compatible with GxuXformCreateProjection_Exact.
+   *
+   * Note that the client performs various adjustments to this matrix
+   * depending on the targeted rendering API:
+   *
+   * - For OpenGL, the matrix is converted from left-handed to right-
+   *   handed by flipping the signs of elements 8-11.
+   *
+   * - For Direct3D, the matrix is kept left-handed, but the depth range
+   *   is converted from -1-to-1 to 0-to-1.
+   *
+   * @param {Number} fovy Vertical field of view (in radians)
    * @param {Number} aspect Aspect ratio
    * @param {Number} near Near frustum
    * @param {Number} far Far frustum
    * @returns {Matrix4} Self
    */
-  perspective(fov, aspect, near, far) {
-    const f = 1.0 / Math.tan(fov * 0.5);
-    const ir = 1.0 / (near - far);
+  projectPerspective(fovy, aspect, near, far) {
+    const f = 1.0 / Math.tan(fovy * 0.5);
+    const ir = 1.0 / (far - near);
 
     this[0]  = f / aspect;
     this[1]  = 0.0;
@@ -261,15 +275,36 @@ class Matrix4 extends Float32Array {
 
     this[8]  = 0.0;
     this[9]  = 0.0;
-    this[10] = (near + far) * ir;
-    this[11] = -1.0;
+    this[10] = (far + near) * ir;
+    this[11] = 1.0;
 
     this[12] = 0.0;
     this[13] = 0.0;
-    this[14] = (near * far * 2.0) * ir;
+    this[14] = -(2.0 * far * near) * ir;
     this[15] = 0.0;
 
     return this;
+  }
+
+  /**
+   * Set this matrix to a perspective projection matrix using the given
+   * diagonal field of view, aspect ratio, near frustum, and far frustum.
+   *
+   * The given diagonal field of view is converted to a vertical field of
+   * view prior to calling projectPerspective. All other parameters are
+   * left unchanged.
+   *
+   * This implementation is compatible with GxuXformCreateProjection_SG.
+   *
+   * @param {Number} fovd Diagonal field of view (in radians)
+   * @param {Number} aspect Aspect ratio
+   * @param {Number} near Near frustum
+   * @param {Number} far Far frustum
+   * @returns {Matrix4} Self
+   */
+  projectPerspectiveDiagonal(fovd, aspect, near, far) {
+    const fovy = fovd / Math.sqrt(aspect * aspect + 1.0);
+    return this.projectPerspective(fovy, aspect, near, far);
   }
 
   /**

--- a/src/specs/matrix4.spec.js
+++ b/src/specs/matrix4.spec.js
@@ -226,17 +226,110 @@ describe('Matrix4', () => {
     });
   });
 
-  describe('prototype.perspective()', () => {
-    test('creates perspective projection', () => {
+  describe('prototype.projectPerspectiveDiagonal()', () => {
+    test('creates projection matrix from sampled data a', () => {
       const matrix = new Matrix4();
 
-      matrix.perspective(45.0 * DEG2RAD, 1920.0 / 1080.0, 0.1, 1000.0);
+      matrix.projectPerspectiveDiagonal(2.094395161, 1.777777791, 0.2222222239, 2777.777832);
 
       expect(matrix.approximates(Matrix4.of(
-        1.35799, 0.0,      0.0,      0.0, // col 0
-        0.0,     2.41421,  0.0,      0.0, // col 1
-        0.0,     0.0,     -1.00020, -1.0, // col 2
-        0.0,     0.0,     -0.20002,  0.0  // col 3
+        0.997638464, 0.0,          0.0,          0.0, // col 0
+        0.0,         1.773579478,  0.0,          0.0, // col 1
+        0.0,         0.0,          1.000159979,  1.0, // col 2
+        0.0,         0.0,         -0.4444800019, 0.0  // col 3
+      ))).toBe(true);
+    });
+
+    test('creates projection matrix from sampled data b', () => {
+      const matrix = new Matrix4();
+
+      matrix.projectPerspectiveDiagonal(1.134464025, 1.777777791, 0.2222222239, 611.111145);
+
+      expect(matrix.approximates(Matrix4.of(
+        1.970299959, 0.0,          0.0,          0.0, // col 0
+        0.0,         3.502755404,  0.0,          0.0, // col 1
+        0.0,         0.0,          1.000727534,  1.0, // col 2
+        0.0,         0.0,         -0.4446061254, 0.0  // col 3
+      ))).toBe(true);
+    });
+  });
+
+  describe('prototype.projectPerspective()', () => {
+    test('creates projection matrix with 90 degree fov', () => {
+      const matrix = new Matrix4();
+
+      matrix.projectPerspective(90.0 * DEG2RAD, 1280.0 / 960.0, 1.0, 1000.0);
+
+      expect(matrix.approximates(Matrix4.of(
+        0.7499999404, 0.0,  0.0,         0.0, // col 0
+        0.0,          1.0,  0.0,         0.0, // col 1
+        0.0,          0.0,  1.002002001, 1.0, // col 2
+        0.0,          0.0, -2.002002001, 0.0  // col 3
+      ))).toBe(true);
+    });
+
+    test('creates projection matrix with 179.99 degree fov', () => {
+      const matrix = new Matrix4();
+
+      matrix.projectPerspective(179.99 * DEG2RAD, 1280.0 / 960.0, 1.0, 1000.0);
+
+      expect(matrix.approximates(Matrix4.of(
+        0.00006541310722, 0.0,             0.0,         0.0, // col 0
+        0.0,              0.000087217486,  0.0,         0.0, // col 1
+        0.0,              0.0,             1.002002001, 1.0, // col 2
+        0.0,              0.0,            -2.002002001, 0.0  // col 3
+      ))).toBe(true);
+    });
+
+    test('creates projection matrix with very close near depth', () => {
+      const matrix = new Matrix4();
+
+      matrix.projectPerspective(90.0 * DEG2RAD, 1920.0 / 1080.0, 0.001, 1000.0);
+
+      expect(matrix.approximates(Matrix4.of(
+        0.5625, 0.0,  0.0,           0.0, // col 0
+        0.0,    1.0,  0.0,           0.0, // col 1
+        0.0,    0.0,  1.000002027,   1.0, // col 2
+        0.0,    0.0, -0.00200000219, 0.0  // col 3
+      ))).toBe(true);
+    });
+
+    test('creates projection matrix with very close near and far depth', () => {
+      const matrix = new Matrix4();
+
+      matrix.projectPerspective(90.0 * DEG2RAD, 1920.0 / 1080.0, 0.001, 0.002);
+
+      expect(matrix.approximates(Matrix4.of(
+        0.5625, 0.0,  0.0,           0.0, // col 0
+        0.0,    1.0,  0.0,           0.0, // col 1
+        0.0,    0.0,  3.0,           1.0, // col 2
+        0.0,    0.0, -0.00400000019, 0.0  // col 3
+      ))).toBe(true);
+    });
+
+    test('creates projection matrix from sampled data a', () => {
+      const matrix = new Matrix4();
+
+      matrix.projectPerspective(1.256636977, 1.333333492, 0.2222222239, 2777.777832);
+
+      expect(matrix.approximates(Matrix4.of(
+        1.032286406, 0.0,          0.0,          0.0, // col 0
+        0.0,         1.376381993,  0.0,          0.0, // col 1
+        0.0,         0.0,          1.000159979,  1.0, // col 2
+        0.0,         0.0,         -0.4444800019, 0.0  // col 3
+      ))).toBe(true);
+    });
+
+    test('creates projection matrix from sampled data b', () => {
+      const matrix = new Matrix4();
+
+      matrix.projectPerspective(1.026800752, 1.777777791, 0.2222222239, 2777.777832);
+
+      expect(matrix.approximates(Matrix4.of(
+        0.997638464, 0.0,          0.0,          0.0, // col 0
+        0.0,         1.773579478,  0.0,          0.0, // col 1
+        0.0,         0.0,          1.000159979,  1.0, // col 2
+        0.0,         0.0,         -0.4444800019, 0.0  // col 3
       ))).toBe(true);
     });
   });


### PR DESCRIPTION
* `perspective` has been renamed `projectPerspective` and is now compatible with the primary perspective projection function in the retail client: `GxuXformCreateProjection_Exact`

* `projectPerspectiveDiagonal` has been implemented, compatible with `GxuXformCreateProjection_SG` in the client

Closes #10 