### PR TITLE
Tweak package.json

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,2 @@
+fallenoak (https://github.com/fallenoak)
+timkurvers (https://github.com/timkurvers)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 The Wowser Contributors
+Copyright (c) 2017 Wowser Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -16,19 +16,12 @@
     "README.md",
     "dist"
   ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/wowserhq/wowser-math.git"
-  },
+  "repository": "wowserhq/wowser-math",
   "keywords": [
     "wowser"
   ],
   "author": "",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/wowserhq/wowser-math/issues"
-  },
-  "homepage": "https://github.com/wowserhq/wowser-math#readme",
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-jest": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
   "keywords": [
     "wowser"
   ],
-  "author": "",
+  "author": "fallenoak",
+  "contributors": [
+    "fallenoak",
+    "timkurvers"
+  ],
   "license": "MIT",
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "wowser-math",
   "version": "0.1.0",
   "description": "Math library for Wowser",
+  "author": "Wowser Contributors",
+  "repository": "github:wowserhq/wowser-math",
+  "license": "MIT",
   "main": "dist/wowser-math.js",
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",
@@ -16,12 +19,9 @@
     "README.md",
     "dist"
   ],
-  "repository": "github:wowserhq/wowser-math",
   "keywords": [
     "wowser"
   ],
-  "author": "Wowser Contributors",
-  "license": "MIT",
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-jest": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "keywords": [
     "wowser"
   ],
-  "author": "fallenoak",
+  "author": "Wowser Contributors",
   "contributors": [
     "fallenoak",
     "timkurvers"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "README.md",
     "dist"
   ],
-  "repository": "wowserhq/wowser-math",
+  "repository": "github:wowserhq/wowser-math",
   "keywords": [
     "wowser"
   ],

--- a/package.json
+++ b/package.json
@@ -21,10 +21,6 @@
     "wowser"
   ],
   "author": "Wowser Contributors",
-  "contributors": [
-    "fallenoak",
-    "timkurvers"
-  ],
   "license": "MIT",
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
This PR uses the GitHub repository shorthand so we don't have to specify `issues`, `repository` and `bugs` separately.

Also includes a proposal for how to handle author and contributors in our packages. I'm a bit unsure whether we want our names and e-mails to pop up, so I added our nicks in there, for now. An alternative would be to set the author to `wowserhq` but according to the npm documentation, [it references a person](https://docs.npmjs.com/files/package.json#people-fields-author-contributors).