### PR TITLE
Fix Quaternion type in docs

### DIFF
--- a/src/lib/matrix4.js
+++ b/src/lib/matrix4.js
@@ -92,7 +92,7 @@ class Matrix4 extends Float32Array {
    * rotation, and scale.
    *
    * @param {Vector3} p Position vector
-   * @param {Quat} r Rotation quaternion
+   * @param {Quaternion} r Rotation quaternion
    * @param {Vector3} s Scale vector
    * @returns {Matrix4} Self
    */

--- a/src/lib/quaternion.js
+++ b/src/lib/quaternion.js
@@ -184,7 +184,7 @@ class Quaternion extends Float32Array {
    * Create a new quaternion with a variable number of arguments.
    *
    * @param {...*} args Arguments for new quaternion
-   * @returns {Quat} New quaternion
+   * @returns {Quaternion} New quaternion
    */
   static of(...args) {
     if (args.length === 0) {


### PR DESCRIPTION
Checked out the docs, super nice 👍

Was just wondering whether these type references should be `Quaternion` instead of `Quat`.